### PR TITLE
feat(player): move basic styles from CSS to JavaScript

### DIFF
--- a/assets/rx-player.css
+++ b/assets/rx-player.css
@@ -12,15 +12,3 @@ rx-player * {
     /* box-shadow: 0 0 1px gold; */
     box-sizing: border-box;
 }
-
-/* force the youtube iframe to act as a block */
-rx-player .hr-yt-wrapper iframe {
-    display: block;
-}
-
-/* force the video element to fit its container */
-rx-player .hr-yt-wrapper video {
-    display: block;
-    height: 100%;
-    width: 100%;
-}

--- a/demo/overlay-html5/index.html
+++ b/demo/overlay-html5/index.html
@@ -22,7 +22,7 @@
 
     </head>
     <body>
-        <div>
+        <div style="height: 360px; width: 640px;">
             <overlay-demo-html5></overlay-demo-html5>
         </div>
 

--- a/demo/overlay/index.html
+++ b/demo/overlay/index.html
@@ -21,7 +21,9 @@
 
     </head>
     <body>
-        <overlay-demo></overlay-demo>
+        <div style="height: 360px; width: 640px;">
+            <overlay-demo></overlay-demo>
+        </div>
     </body>
 
 </html>

--- a/rx-player/players/html5/html5-player.model.ts
+++ b/rx-player/players/html5/html5-player.model.ts
@@ -37,6 +37,11 @@ export class HTML5Player
 
     constructor (elm: HTML5Player, public options: IHTML5PlayerOptions) {
         const $video = angular.element(this.video);
+
+        $video.css('display', 'block');
+        $video.css('height', `${options.height || 360}px`);
+        $video.css('width', `${options.width || 640}px`);
+
         options.sources
             .map(source => angular.element(`<source src="${source.src}" type="${source.type}">`))
             .forEach(sourceElm => $video.append(sourceElm));

--- a/rx-player/players/html5/html5-player.model.ts
+++ b/rx-player/players/html5/html5-player.model.ts
@@ -39,8 +39,8 @@ export class HTML5Player
         const $video = angular.element(this.video);
 
         $video.css('display', 'block');
-        $video.css('height', `${options.height || 360}px`);
-        $video.css('width', `${options.width || 640}px`);
+        $video.css('height', '100%');
+        $video.css('width', '100%');
 
         options.sources
             .map(source => angular.element(`<source src="${source.src}" type="${source.type}">`))

--- a/rx-player/players/html5/html5-player.service.ts
+++ b/rx-player/players/html5/html5-player.service.ts
@@ -29,8 +29,8 @@ export function loadPlayer (elm, options: IHTML5PlayerOptions): Promise<HTML5Pla
 // TODO: This is so far equal to the YoutubePlayer fn
 export function createVideoPlayer (options: IHTML5PlayerOptions, $videoDiv): Observable<IVideoPlayer> {
     return Observable.create(observer => {
-        options.height = options.height || '360';
-        options.width = options.width || '640';
+        options.height = options.height || '100%';
+        options.width = options.height || '100%';
 
         // TODO: Need to see where to put this after refactor
         // this.elm.css('height', convertToUnits(options.height));

--- a/rx-player/players/rx-player.component.html
+++ b/rx-player/players/rx-player.component.html
@@ -1,4 +1,4 @@
-<div class="hr-yt-wrapper">
+<div class="hr-yt-wrapper" style="height: 100%;">
     <div class="hr-yt-video-place-holder"></div>
     <div class="hr-yt-overlay" ng-transclude=""></div>
 </div>

--- a/rx-player/players/rx-player.component.ts
+++ b/rx-player/players/rx-player.component.ts
@@ -100,6 +100,7 @@ export class RxPlayerComponent {
                                 // .info('setting width and height')
                                 .do(player => {
                                     // TODO: Need to see where to put this after refactor
+                                    this.elm.css('display', 'block');
                                     this.elm.css('height', convertToUnits(player.options.height));
                                     this.elm.css('width', convertToUnits(player.options.width));
                                 }),

--- a/rx-player/players/youtube/youtube.service.ts
+++ b/rx-player/players/youtube/youtube.service.ts
@@ -55,8 +55,8 @@ let defaultOptions: YT.PlayerOptions = {
         origin: location.origin + '/',
         enablejsapi: 1
     },
-    height: '360',
-    width: '640'
+    height: '100%',
+    width: '100%'
 };
 
 export type IYoutubePlayerOptions = YT.PlayerOptions;


### PR DESCRIPTION
Este PR agrega estilos básicos al player desde JavaScript y no por CSS.
Esto nos permite usarlo sin necesidad de agregar CSS "para que al menos se vea".

![gw_4ep](https://cloud.githubusercontent.com/assets/4248944/24726027/44265aa2-1a27-11e7-8725-27ae436c5bad.gif)
